### PR TITLE
feat: update hero logo

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,9 +14,22 @@ export default function HomePage() {
     <>
       <JsonLdOrganization />
       <section className="relative bg-black text-white">
+        <Image
+          src="/images/logo/logo-primary.png"
+          alt="The Jorge Ramirez Group logo"
+          width={160}
+          height={40}
+          className="absolute top-6 left-6 z-10 h-auto w-40"
+        />
         <div className="absolute inset-0">
           <div className="absolute inset-0 bg-black/40" />
-          <Image src="/images/hero.webp" alt="Luxury NJ real estate" fill priority className="object-cover opacity-70" />
+          <Image
+            src="https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1920&q=80"
+            alt="Luxury NJ real estate"
+            fill
+            priority
+            className="object-cover opacity-70"
+          />
         </div>
         <div className="container relative py-28 lg:py-40">
           <h1 className="font-serif text-4xl md:text-6xl max-w-3xl">

--- a/credits.md
+++ b/credits.md
@@ -1,3 +1,5 @@
 # Image Credits
 Replace placeholder images with your licensed/royalty‑free photos (Unsplash/Pexels/your uploads).
 List sources and attributions here.
+
+- Hero background: Photo from [Unsplash](https://unsplash.com/photos/d24dbb6b0267)

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,8 @@ module.exports = {
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       // Replace with your real IDX/CDN host(s) when live
-      { protocol: 'https', hostname: '**.your-idx-cdn.com' }
+      { protocol: 'https', hostname: '**.your-idx-cdn.com' },
+      { protocol: 'https', hostname: 'images.unsplash.com' }
     ]
   }
 };


### PR DESCRIPTION
## Summary
- overlay brand logo in hero's top-left corner
- load hero background from Unsplash instead of local asset and credit the source
- allow Unsplash images in Next.js config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad02cf63e883279580860c52c47123