### PR TITLE
Add interactive commuting guide with train line details

### DIFF
--- a/app/resources/commuting-guide/commuting-guide.tsx
+++ b/app/resources/commuting-guide/commuting-guide.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useState } from 'react';
+import { RailMap } from '@/components/rail-map';
+import { trainLines, TrainLine } from '@/lib/train-lines';
+
+export default function CommutingGuide() {
+  const [selected, setSelected] = useState<TrainLine>(trainLines[0]);
+
+  return (
+    <div className="container py-16">
+      <h1 className="font-serif text-4xl">Commuting Guide</h1>
+      <div className="mt-8 flex flex-col lg:flex-row gap-8">
+        <div className="flex-1">
+          <RailMap selectedId={selected.id} onSelect={setSelected} />
+        </div>
+        <div className="lg:w-1/3 border rounded-2xl p-6 bg-white">
+          <h2 className="font-serif text-2xl mb-4">Line Details</h2>
+          <p className="font-semibold flex items-center gap-2">
+            <span
+              className="w-4 h-4 rounded-full"
+              style={{ backgroundColor: selected.color }}
+            />
+            {selected.name}
+          </p>
+          <ul className="mt-4 list-disc pl-5 space-y-1">
+            {selected.towns.map((town) => (
+              <li key={town}>{town}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/resources/commuting-guide/page.tsx
+++ b/app/resources/commuting-guide/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import CommutingGuide from './commuting-guide';
+
+export const metadata: Metadata = {
+  title: 'Commuting Guide',
+  description: 'NJ Transit lines serving Union, Morris, and Essex counties',
+};
+
+export default function Page() {
+  return <CommutingGuide />;
+}

--- a/components/rail-map.tsx
+++ b/components/rail-map.tsx
@@ -1,9 +1,35 @@
-import Image from "next/image";
-export function RailMap() {
+'use client';
+import { trainLines, TrainLine } from '@/lib/train-lines';
+
+interface RailMapProps {
+  onSelect: (line: TrainLine) => void;
+  selectedId: string;
+}
+
+export function RailMap({ onSelect, selectedId }: RailMapProps) {
   return (
     <div className="rounded-2xl overflow-hidden border">
-      <Image src="/images/commuter-map.svg" alt="NYC ↔ Union/Morris/Essex commuter lines" width={1600} height={1000} className="w-full h-auto" />
-      <p className="sr-only">Schematic map showing NJ Transit commuter paths between NYC and Union, Morris, and Essex counties.</p>
+      <svg
+        viewBox="0 0 1600 1000"
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-full h-auto"
+      >
+        <rect width="1600" height="1000" fill="#ffffff" />
+        {trainLines.map((line) => (
+          <path
+            key={line.id}
+            d={line.path}
+            stroke={line.color}
+            strokeWidth={selectedId === line.id ? 8 : 6}
+            fill="none"
+            className="cursor-pointer transition-opacity"
+            onClick={() => onSelect(line)}
+          />
+        ))}
+      </svg>
+      <p className="sr-only">
+        Schematic map showing NJ Transit commuter paths between NYC and Union, Morris, and Essex counties.
+      </p>
     </div>
   );
 }

--- a/lib/train-lines.ts
+++ b/lib/train-lines.ts
@@ -1,0 +1,31 @@
+export interface TrainLine {
+  id: string;
+  name: string;
+  color: string;
+  path: string;
+  towns: string[];
+}
+
+export const trainLines: TrainLine[] = [
+  {
+    id: 'raritan',
+    name: 'Raritan Valley Line',
+    color: '#E3252C',
+    path: 'M150 800 C 400 600, 800 600, 1200 400',
+    towns: ['Newark', 'Union', 'Roselle Park', 'Cranford', 'Garwood', 'Westfield', 'Fanwood', 'Plainfield']
+  },
+  {
+    id: 'morris',
+    name: 'Morris & Essex Line',
+    color: '#006848',
+    path: 'M150 700 C 450 500, 900 500, 1350 350',
+    towns: ['Newark', 'East Orange', 'South Orange', 'Maplewood', 'Millburn', 'Summit', 'New Providence', 'Berkeley Heights']
+  },
+  {
+    id: 'gladstone',
+    name: 'Gladstone Branch',
+    color: '#0057B8',
+    path: 'M150 600 C 500 450, 950 450, 1450 300',
+    towns: ['Summit', 'Chatham', 'Madison', 'Morristown', 'Morris Plains', 'Denville', 'Dover']
+  }
+];


### PR DESCRIPTION
## Summary
- add dataset of NJ Transit lines with color coding and served towns
- build interactive rail map component highlighting selected line
- create commuting guide page showing map with line details box

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad1e5487148327975dfc481cd9b48f